### PR TITLE
feat: Enhance API security and refactor DTOs for consistent responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snippet-manager-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "author": "jj-carrillo-dev",
   "private": true,

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from '../user/user.service';
-import { User } from '../user/entities/user.entity';
+import { UserResponseDto } from 'src/user/dto/UserResponseDto';
 
 /**
  * Passport strategy for JWT authentication.
@@ -36,7 +36,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
    * @returns A promise that resolves to the user object.
    * @throws UnauthorizedException if the user does not exist.
    */
-  async validate(payload: any): Promise<User> {
+  async validate(payload: any): Promise<UserResponseDto> {
     const user = await this.userService.findOne(payload.sub);
     if (!user) {
       throw new UnauthorizedException();

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -5,7 +5,7 @@ import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 import type { RequestWithUser } from 'src/common/interfaces/request-with-user.interface';
 
-@Controller('category')
+@Controller('categories')
 @UseGuards(AuthGuard('jwt')) // Protects all endpoints in this controller
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}

--- a/src/category/dto/CategoryResponseDto.ts
+++ b/src/category/dto/CategoryResponseDto.ts
@@ -1,0 +1,64 @@
+import { Exclude, Expose, Type } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+import { Category } from '../entities/category.entity';
+import { UserResponseDto } from './UserResponseDto';
+
+/**
+ * Data Transfer Object for a category response.
+ * This class defines the structure of the data sent back to the client
+ * after a category is retrieved.
+ */
+@Exclude()
+export class CategoryResponseDto {
+  /**
+   * The unique identifier for the category.
+   */
+  @Expose()
+  @IsNumber()
+  id: number;
+
+  /**
+   * The name of the category (e.g., "Work", "JavaScript").
+   */
+  @Expose()
+  @IsString()
+  name: string;
+
+  /**
+   * The ID of the user who owns the category.
+   */
+  @Exclude()
+  @IsNumber()
+  userId: number;
+
+  /**
+   * The user who owns this category.
+   * The `@Type` decorator ensures the nested user object is correctly transformed.
+   */
+  @Expose()
+  @Type(() => UserResponseDto)
+  user: UserResponseDto;
+
+
+  /**
+   * The date and time when the category was created.
+   * This field is exposed to the client.
+   */
+  @Expose()
+  createdAt: Date;
+
+  /**
+   * The date and time when the category was last updated.
+   * This field is exposed to the client.
+   */
+  @Expose()
+  updatedAt: Date;
+
+  /**
+   * Constructor to create a DTO instance from a partial Category entity.
+   * @param category A partial Category object.
+   */
+  constructor(category: Partial<Category>) {
+    Object.assign(this, category);
+  }
+}

--- a/src/category/dto/UserResponseDto.ts
+++ b/src/category/dto/UserResponseDto.ts
@@ -1,0 +1,11 @@
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+export class UserResponseDto {
+
+    @Expose()
+    guid: string;
+
+    @Expose()
+    username: string;
+}

--- a/src/category/entities/category.entity.ts
+++ b/src/category/entities/category.entity.ts
@@ -1,4 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { Snippet } from '../../snippet/entities/snippet.entity';
 
@@ -21,10 +30,24 @@ export class Category {
   name: string;
 
   /**
+   * The date and time when the category was created.
+   * This column is automatically set by TypeORM when a new category is saved.
+   */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * The date and time when the category was last updated.
+   * This column is automatically updated by TypeORM every time the entity is saved.
+   */
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /**
    * The User entity that owns this category.
    * This is a Many-to-One relationship.
    */
-  @ManyToOne(() => User, user => user.categories)
+  @ManyToOne(() => User, (user) => user.categories)
   @JoinColumn({ name: 'userId' })
   user: User;
 
@@ -38,6 +61,6 @@ export class Category {
    * An array of Snippet entities belonging to this category.
    * This is a One-to-Many relationship.
    */
-  @OneToMany(() => Snippet, snippet => snippet.category)
+  @OneToMany(() => Snippet, (snippet) => snippet.category)
   snippets: Snippet[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,13 @@ async function bootstrap() {
   // Apply the global validation pipe
   app.useGlobalPipes(new ValidationPipe());
 
+    // Enable CORS with specific origin
+  app.enableCors({
+    origin: 'http://localhost:4200', // This is your Angular app's URL
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    credentials: true,
+  });
+
   // Apply the global class serializer interceptor
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
   await app.listen(process.env.PORT ?? 3000);

--- a/src/snippet/dto/CategoryResponseDto.ts
+++ b/src/snippet/dto/CategoryResponseDto.ts
@@ -1,6 +1,7 @@
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 import { IsNumber, IsString } from 'class-validator';
-import { Category } from '../entities/category.entity';
+import { Category } from 'src/category/entities/category.entity';
+import { UserResponseDto } from 'src/user/dto/UserResponseDto';
 
 /**
  * Data Transfer Object for a category response.
@@ -23,12 +24,14 @@ export class CategoryResponseDto {
   @IsString()
   name: string;
 
+
   /**
-   * The ID of the user who owns the category.
+   * The user who owns this category.
+   * The `@Type` decorator ensures the nested user object is correctly transformed.
    */
   @Expose()
-  @IsNumber()
-  userId: number;
+  @Type(() => UserResponseDto)
+  user: UserResponseDto;
 
   /**
    * Constructor to create a DTO instance from a partial Category entity.

--- a/src/snippet/dto/SnippetResponseDto.ts
+++ b/src/snippet/dto/SnippetResponseDto.ts
@@ -1,12 +1,13 @@
-import { Expose, Type } from 'class-transformer';
-import { User } from '../../user/entities/user.entity';
-import { Category } from '../../category/entities/category.entity';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { UserResponseDto } from './UserResponseDto';
+import { CategoryResponseDto } from './CategoryResponseDto';
 
 /**
  * Data Transfer Object for a snippet response.
  * This class defines the structure of the data sent back to the client
  * after a snippet is retrieved, ensuring only exposed properties are included.
  */
+@Exclude()
 export class SnippetResponseDto {
   /**
    * The unique identifier of the snippet.
@@ -33,18 +34,32 @@ export class SnippetResponseDto {
   language: string;
 
   /**
+   * The date and time when the snippet was created.
+   * This field is exposed to the client.
+   */
+  @Expose()
+  createdAt: Date;
+
+  /**
+   * The date and time when the snippet was last updated.
+   * This field is exposed to the client.
+   */
+  @Expose()
+  updatedAt: Date;
+
+  /**
    * The user who owns this snippet.
    * The `@Type` decorator ensures the nested user object is correctly transformed.
    */
   @Expose()
-  @Type(() => User)
-  user: User;
+  @Type(() => UserResponseDto)
+  user: UserResponseDto;
 
   /**
    * The category this snippet belongs to.
    * The `@Type` decorator ensures the nested category object is correctly transformed.
    */
   @Expose()
-  @Type(() => Category)
-  category: Category;
+  @Type(() => CategoryResponseDto)
+  category: CategoryResponseDto;
 }

--- a/src/snippet/dto/UserResponseDto.ts
+++ b/src/snippet/dto/UserResponseDto.ts
@@ -1,0 +1,11 @@
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+export class UserResponseDto {
+    
+    @Expose()
+    guid: string;
+
+    @Expose()
+    username: string;
+}

--- a/src/snippet/entities/snippet.entity.ts
+++ b/src/snippet/entities/snippet.entity.ts
@@ -1,4 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Exclude } from 'class-transformer';
 import { User } from '../../user/entities/user.entity';
 import { Category } from '../../category/entities/category.entity';
@@ -34,10 +42,24 @@ export class Snippet {
   language: string;
 
   /**
+   * The date and time when the snippet was created.
+   * This column is automatically set by TypeORM when a new snippet is saved.
+   */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * The date and time when the snippet was last updated.
+   * This column is automatically updated by TypeORM every time the entity is saved.
+   */
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /**
    * The User entity that owns this snippet.
    * This is a Many-to-One relationship to the User entity.
    */
-  @ManyToOne(() => User, user => user.snippets)
+  @ManyToOne(() => User, (user) => user.snippets)
   @JoinColumn({ name: 'userId' })
   user: User;
 
@@ -53,7 +75,7 @@ export class Snippet {
    * The Category entity this snippet belongs to.
    * This is a Many-to-One relationship to the Category entity.
    */
-  @ManyToOne(() => Category, category => category.snippets)
+  @ManyToOne(() => Category, (category) => category.snippets)
   @JoinColumn({ name: 'categoryId' })
   category: Category;
 

--- a/src/snippet/snippet.controller.ts
+++ b/src/snippet/snippet.controller.ts
@@ -3,10 +3,10 @@ import { AuthGuard } from '@nestjs/passport';
 import { SnippetService } from './snippet.service';
 import { CreateSnippetDto } from './dto/create-snippet.dto';
 import { UpdateSnippetDto } from './dto/update-snippet.dto';
-import { SnippetResponseDto } from './dto/snippet-response.dto';
+import { SnippetResponseDto } from './dto/SnippetResponseDto';
 import type { RequestWithUser } from 'src/common/interfaces/request-with-user.interface';
 
-@Controller('snippet')
+@Controller('snippets')
 @UseGuards(AuthGuard('jwt')) // Protect all routes in this controller with JWT authentication
 export class SnippetController {
   constructor(private readonly snippetService: SnippetService) {}

--- a/src/snippet/snippet.module.ts
+++ b/src/snippet/snippet.module.ts
@@ -4,9 +4,10 @@ import { SnippetService } from './snippet.service';
 import { SnippetController } from './snippet.controller';
 import { Snippet } from './entities/snippet.entity';
 import { CategoryModule } from '../category/category.module';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Snippet]), CategoryModule],
+  imports: [TypeOrmModule.forFeature([Snippet]), CategoryModule, UserModule],
   controllers: [SnippetController],
   providers: [SnippetService],
 })

--- a/src/user/dto/UserResponseDto.ts
+++ b/src/user/dto/UserResponseDto.ts
@@ -1,0 +1,19 @@
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+export class UserResponseDto {
+    @Expose()
+    id: number;
+
+    @Expose()
+    guid: string;
+
+    @Expose()
+    email: string;
+
+    @Expose()
+    username: string;
+
+    @Exclude()
+    password?: string;
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,4 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, BeforeInsert } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  BeforeInsert,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Category } from '../../category/entities/category.entity';
 import { Snippet } from '../../snippet/entities/snippet.entity';
 import { v4 as uuidv4 } from 'uuid';
@@ -46,17 +54,31 @@ export class User {
   password?: string;
 
   /**
+   * The date and time when the user was created.
+   * This column is automatically set by TypeORM when a new user is saved.
+   */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * The date and time when the user was last updated.
+   * This column is automatically updated by TypeORM every time the entity is saved.
+   */
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /**
    * A one-to-many relationship with the Category entity.
    * This links a user to all the categories they have created.
    */
-  @OneToMany(() => Category, category => category.user)
+  @OneToMany(() => Category, (category) => category.user)
   categories: Category[];
 
   /**
    * A one-to-many relationship with the Snippet entity.
    * This links a user to all the snippets they have created.
    */
-  @OneToMany(() => Snippet, snippet => snippet.user)
+  @OneToMany(() => Snippet, (snippet) => snippet.user)
   snippets: Snippet[];
 
   /**

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,6 +4,7 @@ import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
+import { UserResponseDto } from './dto/UserResponseDto';
 
 @Controller('user')
 @UsePipes(new ValidationPipe({ whitelist: true }))
@@ -17,7 +18,7 @@ export class UserController {
    * @returns A promise that resolves to the newly created user entity.
    */
   @Post()
-  create(@Body() createUserDto: CreateUserDto): Promise<User> {
+  create(@Body() createUserDto: CreateUserDto): Promise<UserResponseDto> {
     return this.userService.create(createUserDto);
   }
 
@@ -28,7 +29,7 @@ export class UserController {
    */
   @UseGuards(AuthGuard('jwt'))
   @Get()
-  findAll(): Promise<User[]> {
+  findAll(): Promise<UserResponseDto[]> {
     return this.userService.findAll();
   }
 
@@ -40,7 +41,7 @@ export class UserController {
    */
   @UseGuards(AuthGuard('jwt'))
   @Get(':id')
-  findOneById(@Param('id') id: string): Promise<User> {
+  findOneById(@Param('id') id: string): Promise<UserResponseDto> {
     return this.userService.findOne(+id);
   }
 
@@ -52,7 +53,7 @@ export class UserController {
    */
   @UseGuards(AuthGuard('jwt'))
   @Get('guid/:guid')
-  findOneByGuid(@Param('guid') guid: string): Promise<User> {
+  findOneByGuid(@Param('guid') guid: string): Promise<UserResponseDto> {
     return this.userService.findOneByGuid(guid);
   }
 
@@ -68,7 +69,7 @@ export class UserController {
   update(
     @Param('id') id: string,
     @Body() updateUserDto: UpdateUserDto,
-  ): Promise<User> {
+  ): Promise<UserResponseDto> {
     return this.userService.update(+id, updateUserDto);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,63 +5,67 @@ import * as bcrypt from 'bcrypt';
 import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { plainToInstance } from 'class-transformer';
+import { UserResponseDto } from './dto/UserResponseDto';
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
-  ) { }
+  ) {}
 
   /**
    * Creates a new user in the database.
    * Hashes the password before saving to ensure security.
    * @param createUserDto The data transfer object containing user information.
-   * @returns A promise that resolves to the newly created user entity.
+   * @returns A promise that resolves to the newly created user response object.
    */
-  async create(createUserDto: CreateUserDto): Promise<User> {
+  async create(createUserDto: CreateUserDto): Promise<UserResponseDto> {
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);
     const newUser = this.usersRepository.create({
       ...createUserDto,
       password: hashedPassword,
     });
-    return this.usersRepository.save(newUser);
+    const savedUser = await this.usersRepository.save(newUser);
+    return this.toUserResponseDto(savedUser);
   }
 
   /**
    * Finds all users.
-   * @returns A promise that resolves to an array of all user entities.
+   * @returns A promise that resolves to an array of all user response objects.
    */
-  async findAll(): Promise<User[]> {
-    return this.usersRepository.find();
+  async findAll(): Promise<UserResponseDto[]> {
+    const users = await this.usersRepository.find();
+    return users.map(user => this.toUserResponseDto(user));
   }
 
   /**
    * Finds a single user by their ID.
    * Throws a NotFoundException if the user does not exist.
    * @param id The ID of the user to find.
-   * @returns A promise that resolves to the found user entity.
+   * @returns A promise that resolves to the found user response object.
    */
-  async findOne(id: number): Promise<User> {
+  async findOne(id: number): Promise<UserResponseDto> {
     const user = await this.usersRepository.findOne({ where: { id } });
     if (!user) {
       throw new NotFoundException(`User with ID "${id}" not found`);
     }
-    return user;
+    return this.toUserResponseDto(user);
   }
 
   /**
    * Finds a single user by their globally unique identifier (GUID).
    * Throws a NotFoundException if the user does not exist.
    * @param guid The GUID of the user to find.
-   * @returns A promise that resolves to the found user entity.
+   * @returns A promise that resolves to the found user response object.
    */
-  async findOneByGuid(guid: string): Promise<User> {
+  async findOneByGuid(guid: string): Promise<UserResponseDto> {
     const user = await this.usersRepository.findOne({ where: { guid } });
     if (!user) {
       throw new NotFoundException(`User with GUID "${guid}" not found`);
     }
-    return user;
+    return this.toUserResponseDto(user);
   }
 
   /**
@@ -69,20 +73,16 @@ export class UserService {
    * First finds the user to ensure it exists, then updates the fields and saves.
    * @param id The ID of the user to update.
    * @param updateUserDto The data transfer object with the updated information.
-   * @returns A promise that resolves to the updated user entity.
+   * @returns A promise that resolves to the updated user response object.
    */
-  async update(id: number, updateUserDto: UpdateUserDto): Promise<User> {
+  async update(id: number, updateUserDto: UpdateUserDto): Promise<UserResponseDto> {
     const user = await this.findOne(id); // Re-use findOne to check if user exists
     Object.assign(user, updateUserDto);
-    return this.usersRepository.save(user);
+    const updatedUser = await this.usersRepository.save(user);
+    return this.toUserResponseDto(updatedUser);
   }
 
-  /**
-   * Removes a user from the database.
-   * Throws a NotFoundException if the user does not exist.
-   * @param id The ID of the user to remove.
-   * @returns A promise that resolves to a DeleteResult.
-   */
+  // The 'remove' method does not return a UserResponseDto, as it's a deletion.
   async remove(id: number): Promise<DeleteResult> {
     const user = await this.usersRepository.findOne({ where: { id } });
     if (!user) {
@@ -91,28 +91,27 @@ export class UserService {
     return this.usersRepository.delete(id);
   }
 
-  /**
-   * Finds a single user by their email address.
-   * This method is useful for authentication purposes.
-   * @param email The email address of the user to find.
-   * @returns A promise that resolves to the user entity or undefined if not found.
-   */
+  // The 'findOneByEmail' method is for internal use (e.g., authentication)
   async findOneByEmail(email: string): Promise<User | undefined> {
     const user = await this.usersRepository.findOne({ where: { email } });
     return user ?? undefined;
   }
 
-  /**
-   * Finds a single user based on specified criteria.
-   * Throws a NotFoundException if no user is found.
-   * @param params The TypeORM find options to query the user.
-   * @returns A promise that resolves to the found user entity.
-   */
+  // The 'findOneWithParams' method is also for internal use
   async findOneWithParams(params: any): Promise<User> {
     const user = await this.usersRepository.findOne(params);
     if (!user) {
       throw new NotFoundException(`User not found`);
     }
     return user;
+  }
+
+  /**
+   * Private helper method to transform a User entity to a UserResponseDto.
+   * @param user The User entity to transform.
+   * @returns The transformed UserResponseDto.
+   */
+  private toUserResponseDto(user: User): UserResponseDto {
+    return plainToInstance(UserResponseDto, user, { excludeExtraneousValues: true });
   }
 }


### PR DESCRIPTION
This commit introduces a major refactor to the API's data transfer objects (DTOs) and improves security by controlling which data is sent in API responses. The goal is to prevent sensitive information exposure and standardize the data format across different endpoints.

Implement Response DTOs:

Creates a new UserResponseDto to filter out sensitive user data from public responses.

Creates a new CategoryResponseDto to control category-specific response data.

Refactors SnippetResponseDto to use the new UserResponseDto and CategoryResponseDto, ensuring nested objects are also filtered.

Improve API Security:

Updates login.ts to return only essential user data (id, username) with the access token, preventing full user object exposure.

Modifies category.service.ts and snippet.service.ts to use plainToInstance from class-transformer. This ensures all responses return a standardized DTO instead of the full database entity.

Configures main.ts to use a global ClassSerializerInterceptor to automatically apply DTO transformations to all endpoints.

Standardize Naming and Structure:

Renames category-response.dto.ts and snippet-response.dto.ts to follow a consistent PascalCase naming convention (CategoryResponseDto.ts, SnippetResponseDto.ts).

Removes unnecessary data from nested objects in responses (e.g., category timestamps within a snippet response).